### PR TITLE
Include an option in js-yaml dump call to avoid wrapping at 80 characters

### DIFF
--- a/lib/exporters/exporter.js
+++ b/lib/exporters/exporter.js
@@ -73,7 +73,7 @@ Exporter.prototype.export = function (format) {
 Exporter.prototype._getData = function(format) {
   switch (format) {
     case 'yaml':
-      return YAML.safeDump(JSON.parse(JSON.stringify(this.Data)));
+      return YAML.dump(JSON.parse(JSON.stringify(this.Data)), {lineWidth: -1});
     default:
       return this.Data;
   }

--- a/lib/exporters/raml.js
+++ b/lib/exporters/raml.js
@@ -396,7 +396,7 @@ RAML.prototype._export = function () {
 RAML.prototype._getData = function(format) {
   switch (format) {
     case 'yaml':
-      return '#%RAML 0.8\n'+YAML.safeDump(JSON.parse(JSON.stringify(this.Data)));
+      return '#%RAML 0.8\n'+YAML.dump(JSON.parse(JSON.stringify(this.Data)), {lineWidth: -1});
     default:
       throw Error('RAML doesn not support '+format+' format');
   }

--- a/lib/exporters/swagger.js
+++ b/lib/exporters/swagger.js
@@ -379,8 +379,8 @@ Swagger.prototype._mapEndpointTraitParameters = function (endpoint, existingPara
         // only add it if we didn't already explicitly define it in the operation
         if (!_.find(existingParams, {name: p, in: 'query'})) {
           params.push({
-            $ref: '#/parameters/' + stringHelper.computeTraitName(trait.name, p),
-          })
+            $ref: '#/parameters/' + stringHelper.computeTraitName(trait.name, p)
+          });
         }
       }
     } catch (e) {}
@@ -391,8 +391,8 @@ Swagger.prototype._mapEndpointTraitParameters = function (endpoint, existingPara
         // only add it if we didn't already explicitly define it in the operation
         if (!_.find(existingParams, {name: p, in: 'header'})) {
           params.push({
-            $ref: '#/parameters/' + stringHelper.computeTraitName(trait.name, p),
-          })
+            $ref: '#/parameters/' + stringHelper.computeTraitName(trait.name, p)
+          });
         }
       }
     } catch (e) {}
@@ -418,7 +418,7 @@ Swagger.prototype._mapEndpointTraitResponses = function (endpoint) {
           code = (res.codes && res.codes.length > 0 && parseInt(res.codes[0]) ? res.codes[0] : 'default');
 
       result[code] = {
-        $ref: '#/responses/' + stringHelper.computeTraitName(trait.name, code),
+        $ref: '#/responses/' + stringHelper.computeTraitName(trait.name, code)
       };
     }
   }

--- a/lib/importers/raml.js
+++ b/lib/importers/raml.js
@@ -305,15 +305,15 @@ RAML.prototype._mapTraits = function(traitGroups) {
             _id: k,
             name: k,
             request: {},
-            responses: [],
+            responses: []
           };
 
       if (trait.queryParameters) {
-        slTrait.request.queryString = this._mapQueryString(trait.queryParameters)
+        slTrait.request.queryString = this._mapQueryString(trait.queryParameters);
       }
 
       if (trait.headers) {
-        slTrait.request.headers = this._mapRequestHeaders(trait.headers)
+        slTrait.request.headers = this._mapRequestHeaders(trait.headers);
       }
 
       if (trait.responses) {
@@ -325,7 +325,7 @@ RAML.prototype._mapTraits = function(traitGroups) {
   }
 
   return slTraits;
-}
+};
 
 RAML.prototype._import = function() {
   this.project = new Project(this.data.title);

--- a/lib/importers/swagger.js
+++ b/lib/importers/swagger.js
@@ -512,7 +512,7 @@ Swagger.prototype._mapTraits = function(parameters, responses) {
       _id: k,
       name: k,
       request: {},
-      responses: [],
+      responses: []
     };
 
     trait.request.queryString = this._mapQueryString(queryParams[k]);
@@ -524,7 +524,7 @@ Swagger.prototype._mapTraits = function(parameters, responses) {
       _id: k,
       name: k,
       request: {},
-      responses: [],
+      responses: []
     };
 
     trait.request.headers = this._mapRequestHeaders(headerParams[k]);
@@ -536,7 +536,7 @@ Swagger.prototype._mapTraits = function(parameters, responses) {
       _id: k,
       name: k,
       request: {},
-      responses: [],
+      responses: []
     };
 
     trait.responses = this._mapResponseBody(traitResponses[k], 'application/json');

--- a/lib/utils/json.js
+++ b/lib/utils/json.js
@@ -104,5 +104,5 @@ module.exports = {
     }
 
     return false;
-  },
+  }
 };

--- a/lib/utils/strings.js
+++ b/lib/utils/strings.js
@@ -19,5 +19,5 @@ module.exports = {
     }
 
     return traitName;
-  },
+  }
 };

--- a/test/data/raml-compatible-swagger.json
+++ b/test/data/raml-compatible-swagger.json
@@ -5,6 +5,7 @@
     "title": "Swagger petstore",
     "description": "A sample API"
   },
+  "parameters": {},
   "paths": {
     "/pets/{petName}": {
       "parameters": [
@@ -244,6 +245,7 @@
   },
   "basePath": "/",
   "host": "localhost:3000",
+  "responses": {},
   "schemes": [
     "http",
     "https"

--- a/test/data/swagger.json
+++ b/test/data/swagger.json
@@ -254,5 +254,7 @@
         }
       }
     }
-  }
+  },
+  "parameters": {},
+  "responses": {}
 }

--- a/test/lib/importers/importer.js
+++ b/test/lib/importers/importer.js
@@ -21,7 +21,7 @@ describe('Importer', function(){
       }
       catch(err) {
         expect(err).to.be.instanceof(Error);
-        expect(err.message).to.equal('loadFIle method not implemented');
+        expect(err.message).to.equal('loadFile method not implemented');
       }
     });
   });


### PR DESCRIPTION
I got the following error while trying to convert a RAML generated by `api-spec-converter` to Swagger 2.0:
```
YAMLError: schema is not valid JSON error: 'Unexpected token 'f' at 29:64'
      at Constructor.__dirname.Validator.Validator.validateSchema (node_modules/raml-parser/lib/validator.js:1263:19)
      at Constructor.__dirname.Validator.Validator.validate_body (node_modules/raml-parser/lib/validator.js:1221:20)
      at Constructor.__dirname.Validator.Validator.validate_body (node_modules/raml-parser/lib/validator.js:1176:16)
```
It was caused by js-yaml dump default setting of `lineWidth: 80`: Lines were wrapped causing invalid YAML.
This issue was present in the following api-spec-converter test: 'Converter convert should convert reversly from swagger to raml without loss'.
**Also ran the linter and fixed several errors found there.**